### PR TITLE
[Xposed] Close .oat files after reading their header

### DIFF
--- a/runtime/oat.cc
+++ b/runtime/oat.cc
@@ -71,7 +71,7 @@ OatHeader* OatHeader::FromFile(const std::string& filename, std::string* error_m
     *error_msg = StringPrintf("Could not get oat header because file could not be opened: %s", filename.c_str());
     return nullptr;
   }
-  std::unique_ptr<ElfFile> elf_file(ElfFile::Open(file.release(), false, false, error_msg));
+  std::unique_ptr<ElfFile> elf_file(ElfFile::Open(file.get(), false, false, error_msg));
   if (elf_file.get() == nullptr) {
     return nullptr;
   }


### PR DESCRIPTION
Otherwise, resources will be exhausted sooner or later on some ROMs.
This can lead to bootloops or sudden restarts.

Some parts of the code were copied from OpenDexFilesFromImage(), which opens
the file for later use. But in OatHeader::FromFile(), we just want to read
the header and then close the file again.

Fixes rovo89/Xposed#31
